### PR TITLE
feat: adds streams support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
+const { Duplex } = require('stream')
 const { StatusCodes } = require('./src/StatusCodes').factory()
-const { MockRequest } = require('./src/MockRequest').factory(StatusCodes)
+const { MockRequest } = require('./src/MockRequest').factory(StatusCodes, Duplex)
 
 module.exports = { StatusCodes, MockRequest }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-request-queue",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A super-simple mock for the node request library that uses an ordered queue",
   "main": "index.js",
   "scripts": {

--- a/tests/request-pipe-specs.js
+++ b/tests/request-pipe-specs.js
@@ -24,11 +24,13 @@ module.exports = (test, dependencies) => {
 
       this.on('response', (res) => { this.response = res })
       this.on('error', reject)
-      this.on('end', () => resolve({
-        expectedBody: expectedBody,
-        res: this.getResponse(),
-        body: this.getBody()
-      }))
+      this.on('end', () => {
+        resolve({
+          expectedBody: expectedBody,
+          res: this.getResponse(),
+          body: this.getBody()
+        })
+      })
     }
 
     _write (chunk, encoding, next) {


### PR DESCRIPTION
If you don't present request with a callback, it now returns a stream.
You can still `pipe` the same as before, but now you can also act
directly on the stream without having to pipe it.